### PR TITLE
Create a ClusterIP Service for askgov-backend

### DIFF
--- a/.kube/backend/base/kustomization.yaml
+++ b/.kube/backend/base/kustomization.yaml
@@ -1,3 +1,4 @@
 namespace: askgov
 resources:
-- deployment.yaml
+  - deployment.yaml
+  - service.yaml

--- a/.kube/backend/base/service.yaml
+++ b/.kube/backend/base/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: askgov-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: askgov-backend
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
- Created a ClusterIP Service config file for askgov-backend pods
- Once this is merged, askgov-website can access the backend with the url `http://askgov-backend:8000`