### PR TITLE
chore: configure AWS auth for staging

### DIFF
--- a/.kube/frontend/overlays/staging/deployment-patch.yaml
+++ b/.kube/frontend/overlays/staging/deployment-patch.yaml
@@ -23,21 +23,11 @@ spec:
                 secretKeyRef:
                   name: askgovfe-secret
                   key: APP_URL
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: askgovfe-secret
-                  key: AWS_ACCESS_KEY_ID
             - name: AWS_REGION
               valueFrom:
                 secretKeyRef:
                   name: askgovfe-secret
                   key: AWS_REGION
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: askgovfe-secret
-                  key: AWS_SECRET_ACCESS_KEY
             - name: BASE_URL
               valueFrom:
                 secretKeyRef:
@@ -53,21 +43,11 @@ spec:
                 secretKeyRef:
                   name: askgovfe-secret
                   key: ELASTICSEARCH_URL
-            - name: FILE_AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: askgovfe-secret
-                  key: FILE_AWS_ACCESS_KEY_ID
             - name: FILE_AWS_BUCKET_NAME
               valueFrom:
                 secretKeyRef:
                   name: askgovfe-secret
                   key: FILE_AWS_BUCKET_NAME
-            - name: FILE_AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: askgovfe-secret
-                  key: FILE_AWS_SECRET_ACCESS_KEY
             - name: NEXTAUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/frontend/actions/sendMail.ts
+++ b/frontend/actions/sendMail.ts
@@ -3,13 +3,7 @@ import { render } from '@react-email/render';
 import nodemailer from 'nodemailer';
 import { JSXElementConstructor, ReactElement } from 'react';
 
-const sesClient = new SESClient({
-  region: process.env.AWS_REGION || 'us-east-1',
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
-  },
-});
+const sesClient = new SESClient({});
 
 export const sendEmail = async ({
   email,


### PR DESCRIPTION
For staging environment, we don't need the environment variables for AWS access keys.

- Remove AWS access key env variables in the frontend staging deployment
- Remove inline config for the SES client so the SDK can authenticate automatically when deployed to staging