### PR TITLE
add a new endpoint for getQuestionsByAgency

### DIFF
--- a/backend/ask_gov/urls.py
+++ b/backend/ask_gov/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path, include
 from .views import (
     CompletedQuestionListView, QuestionDetailView, AgencyListView, SubmitQuestionView,
-    QuestionsByAgencyView, UserAgencyQuestionsView, SubmitAnswerView,
+    AllQuestionsByAgencyView, UserAgencyQuestionsView, SubmitAnswerView,
     UserAgencyTopicsView, AddTopicView, TopicListView, LikeQuestionView, DislikeQuestionView,
     AssignAgencyToQuestionView, AddAgencyView, AllQuestionListView, TrendingAgenciesView,
     UpdateAgencyView, ChangeAdminIsOpenView, ChangeStaffIsOpenView, SaveDraftQuestionView,
     MarkQuestionAsSpamView, UnSpamQuestionView, UserView, SessionView, AccountView,
-    VerificationTokenView, AddUserView, GetAllUsersView,
+    VerificationTokenView, AddUserView, GetAllUsersView, QuestionsByAgencyView,
     CheckUserEmailExistsView, EditDeleteUserView, QuestionsByTopicAndAgencyView
 )
 
@@ -17,6 +17,7 @@ urlpatterns = [
     path('agencies/', AgencyListView.as_view(), name='agency-list'),
     path('agencies/<int:pk>/', UpdateAgencyView.as_view(), name='update-agency'),
     path('submit-question/', SubmitQuestionView.as_view(), name='submit-question'),
+    path('questions/all/by-agency/<int:agency_id>/', AllQuestionsByAgencyView.as_view(), name='questions-by-agency'),
     path('questions/by-agency/<int:agency_id>/', QuestionsByAgencyView.as_view(), name='questions-by-agency'),
     path('questions/by-agency/<int:agency_id>/topics/<int:topic_id>/', QuestionsByTopicAndAgencyView.as_view(), name='questions_by_topic_and_agency'),
     path('questions/user-agency/', UserAgencyQuestionsView.as_view(), name='user-agency-questions'),

--- a/backend/ask_gov/views.py
+++ b/backend/ask_gov/views.py
@@ -160,7 +160,7 @@ class SubmitQuestionView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class QuestionsByAgencyView(generics.ListAPIView):
+class AllQuestionsByAgencyView(generics.ListAPIView):
     serializer_class = QuestionSerializer
     pagination_class = CustomPagination
     filter_backends = [SearchFilter, DjangoFilterBackend]
@@ -214,7 +214,21 @@ class QuestionsByAgencyView(generics.ListAPIView):
             'unanswered_count': unanswered_count
         })
 
+class QuestionsByAgencyView(APIView):
+    pagination_class = CustomPagination
 
+    def get(self, request, agency_id):
+        agency = get_object_or_404(Agency, pk=agency_id)
+        questions = Question.objects.filter(agency=agency, state='completed').order_by('-likes', 'id')
+        
+        paginator = self.pagination_class()
+        paginated_questions = paginator.paginate_queryset(questions, request)
+        
+        serializer = QuestionSerializer(paginated_questions, many=True)
+        
+        return paginator.get_paginated_response(serializer.data)
+
+    
 class QuestionsByTopicAndAgencyView(APIView):
     pagination_class = CustomPagination
 

--- a/frontend/actions/userServices.ts
+++ b/frontend/actions/userServices.ts
@@ -24,7 +24,7 @@ export async function getUserAgencyQuestions(
       query.set('date', date);
     }
 
-    const response = await fetch(`${API_URL}/questions/by-agency/${agencyId}/?${query.toString()}`, {
+    const response = await fetch(`${API_URL}/questions/all/by-agency/${agencyId}/?${query.toString()}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
a new endpoint for getQuestionsByAgency is added because currently using the same endpoint with admin getUserAgencyQuestions endpoint.

because getUserAgencyQuestions endpoint doesnt send questions with 'completed' state