### PR TITLE
Reorganize question endpoints

### DIFF
--- a/backend/ask_gov/urls.py
+++ b/backend/ask_gov/urls.py
@@ -1,26 +1,22 @@
 from django.urls import path, include
 from .views import (
-    CompletedQuestionListView, QuestionDetailView, AgencyListView, SubmitQuestionView,
-    AllQuestionsByAgencyView, UserAgencyQuestionsView, SubmitAnswerView,
-    UserAgencyTopicsView, AddTopicView, TopicListView, LikeQuestionView, DislikeQuestionView,
-    AssignAgencyToQuestionView, AddAgencyView, AllQuestionListView, TrendingAgenciesView,
-    UpdateAgencyView, ChangeAdminIsOpenView, ChangeStaffIsOpenView, SaveDraftQuestionView,
-    MarkQuestionAsSpamView, UnSpamQuestionView, UserView, SessionView, AccountView,
-    VerificationTokenView, AddUserView, GetAllUsersView, QuestionsByAgencyView,
-    CheckUserEmailExistsView, EditDeleteUserView, QuestionsByTopicAndAgencyView
+    QuestionDetailView, AgencyListView, SubmitQuestionView, SubmitAnswerView,
+    UserAgencyTopicsView, AddTopicView, TopicListView, LikeQuestionView,
+    DislikeQuestionView, AssignAgencyToQuestionView, AddAgencyView,
+    TrendingAgenciesView, UpdateAgencyView, ChangeAdminIsOpenView,
+    ChangeStaffIsOpenView, SaveDraftQuestionView, MarkQuestionAsSpamView,
+    UnSpamQuestionView, UserView, SessionView, AccountView,
+    VerificationTokenView, AddUserView, GetAllUsersView,
+    CheckUserEmailExistsView, EditDeleteUserView, AdminQuestionListView,
+    CompletedQuestionListView, AdminQuestionDetailView
 )
 
 urlpatterns = [
     path('questions/', CompletedQuestionListView.as_view(), name='question-list-create'),
-    path('questions/all/', AllQuestionListView.as_view(), name='all-user-questions'),
     path('questions/<int:pk>/', QuestionDetailView.as_view(), name='question-detail'),
     path('agencies/', AgencyListView.as_view(), name='agency-list'),
     path('agencies/<int:pk>/', UpdateAgencyView.as_view(), name='update-agency'),
     path('submit-question/', SubmitQuestionView.as_view(), name='submit-question'),
-    path('questions/all/by-agency/<int:agency_id>/', AllQuestionsByAgencyView.as_view(), name='questions-by-agency'),
-    path('questions/by-agency/<int:agency_id>/', QuestionsByAgencyView.as_view(), name='questions-by-agency'),
-    path('questions/by-agency/<int:agency_id>/topics/<int:topic_id>/', QuestionsByTopicAndAgencyView.as_view(), name='questions_by_topic_and_agency'),
-    path('questions/user-agency/', UserAgencyQuestionsView.as_view(), name='user-agency-questions'),
     path('questions/<int:question_id>/submit-answer/', SubmitAnswerView.as_view(), name='submit-answer'),
     path('topics/user-agency/<int:agency_id>/', UserAgencyTopicsView.as_view(), name='user-agency-topics'),
     path('topics/add/<int:agency_id>/', AddTopicView.as_view(), name='add-topic'),
@@ -35,13 +31,16 @@ urlpatterns = [
     path('questions/<int:question_id>/save-draft/', SaveDraftQuestionView.as_view(), name='save-draft'),
     path('questions/<int:question_id>/mark-spam/', MarkQuestionAsSpamView.as_view(), name='mark-question-spam'),
     path('questions/<int:question_id>/un-spam/', UnSpamQuestionView.as_view(), name='mark-question-spam'),
-    path('auth/user', UserView.as_view(), name='user'),
-    path('auth/session', SessionView.as_view(), name='session'),
-    path('auth/account', AccountView.as_view(), name='account'),
-    path('auth/verification', VerificationTokenView.as_view(), name='verification'),
-    path('admin/user', AddUserView.as_view(), name='add_user'),
-    path('admin/user/<uuid:id>', EditDeleteUserView.as_view(), name='edit_delete_user'),
-    # path('admin/user/<uuid:id>', DeleteUserView.as_view(), name='delete_user'),
-    path('admin/users', GetAllUsersView.as_view(), name='get_all_users'),
-    path('admin/check-email', CheckUserEmailExistsView.as_view(), name='check_email_exists'),
+    path('auth/user/', UserView.as_view(), name='user'),
+    path('auth/session/', SessionView.as_view(), name='session'),
+    path('auth/account/', AccountView.as_view(), name='account'),
+    path('auth/verification/', VerificationTokenView.as_view(), name='verification'),
+
+    # admin paths
+    path('admin/user/', AddUserView.as_view(), name='add_user'),
+    path('admin/user/<uuid:id>/', EditDeleteUserView.as_view(), name='edit_delete_user'),
+    path('admin/users/', GetAllUsersView.as_view(), name='get_all_users'),
+    path('admin/check-email/', CheckUserEmailExistsView.as_view(), name='check_email_exists'),
+    path('admin/questions/', AdminQuestionListView.as_view(), name='admin-question-list'),
+    path('admin/questions/<int:pk>/', AdminQuestionDetailView.as_view(), name='admin-question-detail')
 ]

--- a/backend/ask_gov/views.py
+++ b/backend/ask_gov/views.py
@@ -27,74 +27,31 @@ class CustomPagination(PageNumberPagination):
     max_page_size = 100
 
 class CompletedQuestionListView(generics.ListCreateAPIView):
+    queryset = Question.objects.trending()
     serializer_class = QuestionSerializer
     pagination_class = CustomPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ['agency', 'topics']
 
-    def get_queryset(self):
-        return Question.objects.trending()
-
-
-class AllQuestionListView(generics.ListAPIView):
-    queryset = Question.objects.all()
+class AdminQuestionListView(generics.ListAPIView):
+    queryset = Question.objects.all().order_by('-created_at')
     serializer_class = QuestionSerializer
     pagination_class = CustomPagination
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    filterset_fields = ['agency', 'state']
+    filterset_fields = {
+            'agency': ['exact', 'isnull'],
+            'state': ['exact'],
+            'answer': ['isnull']
+        }
     search_fields = ['question']
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        tab = self.request.query_params.get('tab', 'all')
-
-        if tab == 'unassigned':
-            queryset = queryset.filter(agency__isnull=True).exclude(state='spam')
-        elif tab == 'assigned':
-            queryset = queryset.filter(agency__isnull=False).exclude(state='spam')
-        elif tab == 'spam':
-            queryset = queryset.filter(state='spam')
-        else:
-            queryset = queryset.exclude(state='spam')
-
-        search_term = self.request.query_params.get('search', None)
-        if search_term:
-            queryset = queryset.filter(
-                question__icontains=search_term
-            )
-
-        date_str = self.request.query_params.get('date', None)
-        if date_str:
-            try:
-                date_obj = datetime.strptime(date_str, '%d%m%Y').date()
-                queryset = queryset.filter(date__date=date_obj)
-            except ValueError:
-                pass
-
-        return queryset
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-
-        unassigned_count = Question.objects.filter(agency__isnull=True).exclude(state='spam').count()
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response({
-                'results': serializer.data,
-                'unassigned_count': unassigned_count
-            })
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response({
-            'results': serializer.data,
-            'unassigned_count': unassigned_count
-        })
-
-
 class QuestionDetailView(generics.RetrieveAPIView):
-    queryset = Question.objects.all()
+    queryset = Question.objects.filter(state='completed')
     serializer_class = QuestionSerializer
 
+class AdminQuestionDetailView(generics.RetrieveAPIView):
+    queryset = Question.objects.all()
+    serializer_class = QuestionSerializer
 
 class AgencyListView(generics.ListAPIView):
     queryset = Agency.objects.all()
@@ -158,100 +115,6 @@ class SubmitQuestionView(APIView):
             )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class AllQuestionsByAgencyView(generics.ListAPIView):
-    serializer_class = QuestionSerializer
-    pagination_class = CustomPagination
-    filter_backends = [SearchFilter, DjangoFilterBackend]
-    filterset_fields = ['state']
-    search_fields = ['question']
-
-    def get_queryset(self):
-        agency_id = self.kwargs['agency_id']
-        agency = get_object_or_404(Agency, pk=agency_id)
-
-        tab = self.request.query_params.get('tab', 'all')
-        search_term = self.request.query_params.get('search', None)
-        date_str = self.request.query_params.get('date', None)
-
-        queryset = Question.objects.filter(agency=agency)
-        if tab == 'unanswered':
-            queryset = queryset.filter(answer__isnull=True)
-        elif tab == 'answered':
-            queryset = queryset.filter(answer__isnull=False)
-        elif tab == 'draft':
-            queryset = queryset.filter(state='draft')
-
-        if search_term:
-            queryset = queryset.filter(question__icontains=search_term)
-
-        if date_str:
-            try:
-                date_obj = datetime.strptime(date_str, '%d%m%Y').date()
-                queryset = queryset.filter(date__date=date_obj)
-            except ValueError:
-                pass  
-
-        return queryset
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-
-        unanswered_count = Question.objects.filter(agency=self.kwargs['agency_id'], answer__isnull=True).count()
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response({
-                'results': serializer.data,
-                'unanswered_count': unanswered_count
-            })
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response({
-            'results': serializer.data,
-            'unanswered_count': unanswered_count
-        })
-
-class QuestionsByAgencyView(APIView):
-    pagination_class = CustomPagination
-
-    def get(self, request, agency_id):
-        agency = get_object_or_404(Agency, pk=agency_id)
-        questions = Question.objects.trending().filter(agency=agency)
-        
-        paginator = self.pagination_class()
-        paginated_questions = paginator.paginate_queryset(questions, request)
-        
-        serializer = QuestionSerializer(paginated_questions, many=True)
-        
-        return paginator.get_paginated_response(serializer.data)
-
-    
-class QuestionsByTopicAndAgencyView(APIView):
-    pagination_class = CustomPagination
-
-    def get(self, request, agency_id, topic_id):
-        agency = get_object_or_404(Agency, pk=agency_id)
-        topic = get_object_or_404(Topic, pk=topic_id)
-        
-        questions = Question.objects.trending().filter(agency=agency, topics=topic)
-        
-        paginator = self.pagination_class()
-        paginated_questions = paginator.paginate_queryset(questions, request)
-        
-        serializer = QuestionSerializer(paginated_questions, many=True)
-        
-        return paginator.get_paginated_response(serializer.data)
-    
-class UserAgencyQuestionsView(APIView):
-    def get(self, request, agency_id):
-        agency = get_object_or_404(Agency, id=agency_id)
-        questions = Question.objects.filter(agency=agency, state='completed')
-        serializer = QuestionSerializer(questions, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
-
 
 class SubmitAnswerView(APIView):
     def post(self, request, question_id):


### PR DESCRIPTION
**Changes**
- Delete redundant /questions endpoints
- Organize /questions endpoints into public and admin views
  - `/api/questions`
  - `/api/questions/:question_id`
  - `/api/admin/questions`
  - `/api/admin/questions/:question_id`
  - Filter questions by using query params