### PR TITLE
Protect admin endpoints

### DIFF
--- a/apps/backend/ask_gov/permissions.py
+++ b/apps/backend/ask_gov/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+from .models import UserRole
+
+class IsSuperAdmin(BasePermission):
+    """
+    Permission to only allow super admin.
+    """
+    message = 'Must be a super admin.'
+    code = 403
+
+    def has_permission(self, request, view):
+        return request.user.role == UserRole.SUPER_ADMIN

--- a/apps/backend/ask_gov/tests/test_views.py
+++ b/apps/backend/ask_gov/tests/test_views.py
@@ -2,8 +2,9 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 
-from ..models import Answer, User, Question, Agency
+from ..models import Answer, User, Question, Agency, UserRole
 
 
 class TestAdminListQuestions(APITestCase):
@@ -19,6 +20,10 @@ class TestAdminListQuestions(APITestCase):
 
     def setUp(self):
         agency = Agency.objects.create(name="Ministry of Education", name_ms="Kementerian Pendidikan", acronym="MOE")
+        user = User.objects.create(name="John Doe", email="johndoe@example.com", agency=agency.id, role=UserRole.STAFF)
+        token = Token.objects.create(user=user)
+        self.client.force_authenticate(user, token)
+
         for i in range(0, self.NUM_BACKLOG):
             Question.objects.create(question=f"Question backlog {i + 1}", agency=agency)
         for i in range (0, self.NUM_SPAM):
@@ -89,16 +94,24 @@ class TestQuestionViewSet(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 class TestAdminQuestionViewSet(APITestCase):
+    NUM_QUESTIONS = 10
+
     def setUp(self):
-        for i in range(0, 10):
+        self.agency = Agency.objects.create(name="Ministry of Education", name_ms="Kementerian Pendidikan", acronym="MOE")
+        for i in range(0, self.NUM_QUESTIONS):
             Question.objects.create(
                 question=f"Question {i + 1}",
                 email="test@example.com",
+                agency=self.agency,
             )
-        self.agency = Agency.objects.create(name="Ministry of Education", name_ms="Kementerian Pendidikan", acronym="MOE")
         self.question = Question.objects.first()
         self.update_question_url = reverse("admin-question-detail", kwargs={"pk": self.question.id})
         self.open_question_url = reverse("admin-question-open", kwargs={"pk": self.question.id})
+        self.list_questions_url = reverse("admin-question-list")
+
+        user = User.objects.create(name="John Doe", email="johndoe@example.com", agency=self.agency.id, role=UserRole.STAFF)
+        token = Token.objects.create(user=user)
+        self.client.force_authenticate(user, token)
 
     def test_assign_agency(self):
         """
@@ -152,6 +165,11 @@ class TestAdminAnswerViewSet(APITestCase):
             question="Test Question",
         )
         self.submit_answer_url = reverse("admin-answer-list")
+
+        user = User.objects.create(name="John Doe", email="johndoe@example.com", agency=agency.id, role=UserRole.STAFF)
+        token = Token.objects.create(user=user)
+        self.client.force_authenticate(user, token)
+        self.user=user
     
     def test_submit_answer(self):
         """
@@ -183,3 +201,43 @@ class TestAdminAnswerViewSet(APITestCase):
         }
         response = self.client.post(self.submit_answer_url, data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_submit_answer_other_agency(self):
+        """
+        Tests user with role `staff` submitting an answer for a different agency.
+        """
+        other_agency = Agency.objects.create(name="Other Ministry", name_ms="Other Ministry", acronym="OM")
+        self.question.agency = other_agency
+        self.question.save()
+        data = {
+            "question": self.question.id,
+            "raw": "<p>Test Answer</p>",
+            "text": "Test Answer",
+            "draft": False,
+        }
+        response = self.client.post(self.submit_answer_url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+class TestAdminTopicViewSet(APITestCase):
+    def setUp(self):
+        agency = Agency.objects.create(name="Ministry of Education", name_ms="Kementerian Pendidikan", acronym="MOE")
+        user = User.objects.create(name="John Doe", email="johndoe@example.com", agency=agency.id, role=UserRole.STAFF)
+        token = Token.objects.create(user=user)
+        self.client.force_authenticate(user, token)
+
+        self.create_topic_url = reverse("admin-topic-list")
+
+    def test_create_for_other_agency(self):
+        """
+        Tests user with role `staff` creating a topic for a different agency.
+        """
+        other_agency = Agency.objects.create(name="Other Ministry", name_ms="Other Ministry", acronym="OM")
+        response = self.client.post(
+            self.create_topic_url,
+            data={
+                "title": "Test Topic",
+                "title_ms": "Test Topic",
+                "agency": other_agency.id,
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/backend/ask_gov/views.py
+++ b/apps/backend/ask_gov/views.py
@@ -1,3 +1,4 @@
+from ask_gov.permissions import IsSuperAdmin
 from .serializers import (
     AdminPatchedQuestionSerializer, AnswerSerializer, QuestionSerializer,
     AgencySerializer, TopicSerializer, UserSerializer,
@@ -7,9 +8,10 @@ from django.utils import timezone
 from rest_framework.filters import SearchFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.decorators import action
-from rest_framework import generics, status, pagination, mixins, viewsets
-from .models import Answer, Question, Agency, Topic, User
+from rest_framework.decorators import action 
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework import generics, status, pagination, mixins, viewsets, exceptions
+from .models import Answer, Question, Agency, Topic, User, UserRole
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
@@ -38,12 +40,14 @@ class QuestionViewSet(
     pagination_class = CustomPagination
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ['agency', 'topics']
+    permission_classes = [AllowAny]
 
 class AnswerViewSet(
     viewsets.GenericViewSet,
 ):
     queryset = Answer.objects.filter(draft=False)
     serializer_class = AnswerSerializer
+    permission_classes = [AllowAny]
 
     @extend_schema(request=None)
     @action(methods=["POST"], detail=True)
@@ -69,6 +73,7 @@ class AgencyViewSet(
 ):
     queryset = Agency.objects.trending()
     serializer_class = AgencySerializer
+    permission_classes = [AllowAny]
 
 class TopicViewSet(
     mixins.ListModelMixin,
@@ -78,6 +83,7 @@ class TopicViewSet(
     serializer_class = TopicSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["agency"]
+    permission_classes = [AllowAny]
 
 class AdminQuestionViewSet(
     mixins.ListModelMixin,
@@ -93,9 +99,14 @@ class AdminQuestionViewSet(
             'agency': ['exact', 'isnull'],
         }
     search_fields = ['question']
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         queryset = self.queryset
+
+        # Filter query by user agency if they are not a super admin
+        if self.request.user.role != UserRole.SUPER_ADMIN:
+            queryset = queryset.filter(agency=self.request.user.agency)
 
         state = self.request.query_params.get('state')
         if state == 'completed':
@@ -136,10 +147,11 @@ class AdminAgencyViewSet(
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
 ):
-    queryset = Agency.objects.all()
+    queryset = Agency.objects.all().order_by("id")
     serializer_class = AgencySerializer
     pagination_class = CustomPagination
     search_fields = ['name', 'name_ms', 'acronym']
+    permission_classes = [IsAuthenticated, IsSuperAdmin]
 
 
 class AdminTopicViewSet(
@@ -154,6 +166,26 @@ class AdminTopicViewSet(
     serializer_class = TopicSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["agency"]
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = self.queryset
+
+        # Filter query by user agency if they are not a super admin
+        if self.request.user.role != UserRole.SUPER_ADMIN:
+            queryset = queryset.filter(agency=self.request.user.agency)
+
+        return queryset
+
+    def perform_create(self, serializer):
+        if self.request.user.agency != serializer.validated_data["agency"].id:
+            raise exceptions.PermissionDenied("Cannot create a topic that does not belong to your agency.")
+        return super().perform_create(serializer)
+    
+    def perform_update(self, serializer):
+        if self.request.user.agency != serializer.validated_data["agency"].id:
+            raise exceptions.PermissionDenied("Cannot update a topic that does not belong to your agency.")
+        return super().perform_update(serializer)
 
 
 class AdminUserViewSet(
@@ -169,6 +201,7 @@ class AdminUserViewSet(
     filter_backends = [DjangoFilterBackend, SearchFilter]
     filterset_fields = ["role", "agency"]
     search_fields = ["name", "email"]
+    permission_classes = [IsAuthenticated, IsSuperAdmin]
 
 
 class AdminAnswerViewSet(
@@ -178,9 +211,22 @@ class AdminAnswerViewSet(
 ):
     queryset = Answer.objects.all()
     serializer_class = AnswerSerializer
+    permission_classes = [IsAuthenticated]
+
+    def perform_create(self, serializer):
+        if self.request.user.agency != serializer.validated_data["question"].agency.id:
+            raise exceptions.PermissionDenied("Cannot create an answer that does not belong to your agency.")
+        return super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        if self.request.user.agency != serializer.validated_data["question"].agency.id:
+            raise exceptions.PermissionDenied("Cannot update an answer that does not belong to your agency.")
+        return super().perform_update(serializer)
 
 
 class CheckUserEmailExistsView(APIView):
+    permission_classes = [AllowAny]
+
     def get(self, request):
         email = request.GET.get('email')
         exists = User.objects.filter(email=email).exists()

--- a/apps/backend/backend/settings.py
+++ b/apps/backend/backend/settings.py
@@ -143,6 +143,9 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication"
     ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ]
 }
 
 # Internationalization


### PR DESCRIPTION
Add permissions to `/admin` endpoints. Requests to `/admin` endpoints will need the `Authorization: Token <access_token>` header.

Some endpoints are exclusive to super_admin role:
- `/admin/agencies/**`
- `/admin/users/**`

Other checks:
- Users can only CRUD questions and topics in their agency